### PR TITLE
Fix pricing output to match CHK expected format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Return prices multiplied by 100, as expected by CHK
 
 ## [0.3.0] - 2021-03-25
 

--- a/node/handlers/formatResponse.ts
+++ b/node/handlers/formatResponse.ts
@@ -5,13 +5,22 @@ export async function formatResponse(ctx: Context) {
 
   const quote = state.quote as Quote
 
+  const convertedQuote: Quote = {
+    skuId: quote.skuId,
+    listPrice: quote.listPrice*100,
+    costPrice: quote.costPrice*100,
+    sellingPrice: quote.sellingPrice*100,
+    priceValidUntil: quote.priceValidUntil,
+    tradePolicyId: quote.tradePolicyId
+  }
+
   const response: ExternalPriceResponse = {
     message: 'Price quoted successfully.',
     item: {
-      price: quote.sellingPrice,
-      priceTables: quote.tradePolicyId ?? '',
+      price: convertedQuote.sellingPrice,
+      priceTables: convertedQuote.tradePolicyId ?? '',
       index: body.item.index,
-      ...quote,
+      ...convertedQuote,
     },
   }
 

--- a/node/handlers/formatResponse.ts
+++ b/node/handlers/formatResponse.ts
@@ -5,22 +5,21 @@ export async function formatResponse(ctx: Context) {
 
   const quote = state.quote as Quote
 
-  const convertedQuote: Quote = {
-    skuId: quote.skuId,
-    listPrice: quote.listPrice*100,
-    costPrice: quote.costPrice*100,
-    sellingPrice: quote.sellingPrice*100,
-    priceValidUntil: quote.priceValidUntil,
-    tradePolicyId: quote.tradePolicyId
-  }
-
+  //Checkout service expect prices coming from Pricing Service to be multiplied by 100
   const response: ExternalPriceResponse = {
     message: 'Price quoted successfully.',
     item: {
-      price: convertedQuote.sellingPrice,
-      priceTables: convertedQuote.tradePolicyId ?? '',
+      price: quote.sellingPrice*100,
+      priceTables: quote.tradePolicyId ?? '',
       index: body.item.index,
-      ...convertedQuote,
+      ...{
+        skuId: quote.skuId,
+        listPrice: quote.listPrice*100,
+        costPrice: quote.costPrice*100,
+        sellingPrice: quote.sellingPrice*100,
+        priceValidUntil: quote.priceValidUntil,
+        tradePolicyId: quote.tradePolicyId
+      },
     },
   }
 

--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,7 @@
     "@types/node": "^12.0.0",
     "@types/node-fetch": "^2.5.8",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.3",
+    "@vtex/api": "6.45.6",
     "@vtex/test-tools": "^1.0.0",
     "@vtex/tsconfig": "^0.5.6",
     "typescript": "3.9.7"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1244,10 +1244,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vtex/api@6.45.3":
-  version "6.45.3"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.3.tgz#fe7d08adb4eab1fda5e34143cc6302a4c5aa5f52"
-  integrity sha512-kiD7We1TCKDyBdpYoh2Se3An+jTJRUzXGNpKifoDZylWQ1PyIx+3oL5ZAif9InlY3uJkfEisSAI6nxoKTgvPfw==
+"@vtex/api@6.45.6":
+  version "6.45.6"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.6.tgz#e5f08476d7c76f26baa1c040666d1364bdd6bc35"
+  integrity sha512-9pDiUxcUzq8RZa9yBex4C8dcAHXBRGAZokvHJ6sykrojq6mJxs+rUTE28TPeeQxwvvKsvrdpsfCUAYQ+UDz+zA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -5253,7 +5253,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
The CHK simulation expects the price return (defined in the Pricing service) to be multiplied by 100.
We did the same in Pricing Hub, as it can be seen [here](https://github.com/vtex/pricing-hub/blob/master/PricingHub/PricingHub.WebApp/Services/External/VtexPriceService.cs#L112).