### PR TITLE
fix: catch exception on get price when 404 and return undefined

### DIFF
--- a/node/clients/externalPrice.ts
+++ b/node/clients/externalPrice.ts
@@ -16,12 +16,16 @@ export default class ExternalPrice
   }
 
   public async getPrice(item: InputItem): Promise<number | undefined> {
-    const result = await this.http.get(item.skuId, {
-      metric: 'get-price',
-    })
+    try {
+      return await this.http.get(item.skuId, {
+        metric: 'get-price',
+      })
+    } catch (e) {
+      if (e.response.status === 404) {
+        return undefined
+      }
 
-    // parse payload and return price as number
-
-    return result
+      throw e
+    }
   }
 }

--- a/node/clients/pricingClient.ts
+++ b/node/clients/pricingClient.ts
@@ -18,8 +18,21 @@ export default class PricingClient extends ExternalClient {
     })
   }
 
-  public getPrice(skuId: string | number, priceTable: string | undefined) {
-    return this.http.get<Quote>(`/prices/${skuId}/computed/${priceTable}`)
+  public async getPrice(
+    skuId: string | number,
+    priceTable: string | undefined
+  ): Promise<Quote | undefined> {
+    try {
+      return await this.http.get<Quote>(
+        `/prices/${skuId}/computed/${priceTable}`
+      )
+    } catch (e) {
+      if (e.response.status === 404) {
+        return undefined
+      }
+
+      throw e
+    }
   }
 }
 

--- a/node/clients/pricingClient.ts
+++ b/node/clients/pricingClient.ts
@@ -20,7 +20,7 @@ export default class PricingClient extends ExternalClient {
 
   public async getPrice(
     skuId: string | number,
-    priceTable: string | undefined
+    priceTable: string
   ): Promise<Quote | undefined> {
     try {
       return await this.http.get<Quote>(


### PR DESCRIPTION
**What is the purpose of this pull request?**
This fix is necessary to avoid the app responding with an error 500 when the price is not found.

Previously, the app didn't handle errors from the client and returned an error 500 instead of 404.

**What problem is this solving?**

It solves the problem of too many retries from Pricing-Hub.